### PR TITLE
make sure we don't insert a space after 'LAUNCHER=' in bin/molpro

### DIFF
--- a/easybuild/easyblocks/m/molpro.py
+++ b/easybuild/easyblocks/m/molpro.py
@@ -240,11 +240,11 @@ class EB_Molpro(ConfigureMake, Binary):
 
         # Make sure that the launcher text we replace (where this is done) is not
         # the instance of setting LAUNCHER that contains the eval.
-        launchertext = r"^(LAUNCHER\s*=\s*)((?!\"`eval echo \$LAUNCHER` \$MOLPRO_OPTIONS\").)*$"
+        launchertext = r"^(LAUNCHER\s*=)\s*((?!\"`eval echo \$LAUNCHER` \$MOLPRO_OPTIONS\").)*$"
         if self.cfg['parallel_launcher'] is not None:
-            apply_regex_substitutions(molpro_exe, [(launchertext, r'\1 "%s"' % self.cfg['parallel_launcher'])])
+            apply_regex_substitutions(molpro_exe, [(launchertext, r'\1"%s"' % self.cfg['parallel_launcher'])])
         elif self.orig_launcher is not None:
-            apply_regex_substitutions(molpro_exe, [(launchertext, r"\1 %s" % self.orig_launcher)])
+            apply_regex_substitutions(molpro_exe, [(launchertext, r'\1"%s"' % self.orig_launcher)])
 
         if self.cleanup_token_symlink:
             try:


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyblocks/pull/928
